### PR TITLE
Fix makefile for creating egress-router image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ unexport GOPATH
 
 GO_BUILD_BINDIR = _output
 GO_BUILD_PACKAGES = \
-    ./cmd/... 
+    ./cmd/...
 GO_BUILD_PACKAGES_EXPANDED =$(shell GO111MODULE=on $(GO) list $(GO_MOD_FLAGS) $(GO_BUILD_PACKAGES))
 
 # Include the library makefile
@@ -26,3 +26,8 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 # It will generate target "image-$(1)" for builing the image and binding it as a prerequisite to target "images".
 
 $(call build-image,egress-router,egress-router,./images/egress-router/Dockerfile,.)
+
+build-image-egress-router-test:
+	podman build --no-cache -f images/egress-router/Dockerfile -t egress-router-test .
+
+.PHONY: build-image-egress-router-test

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -1,0 +1,8 @@
+set -eu
+cmd=egress-router
+eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+GOOS=${GOOS:-${GOHOSTOS}}
+GOARCH=${GOACH:-${GOHOSTARCH}}
+GOFLAGS=${GOFLAGS:-}
+GLDFLAGS=${GLDFLAGS:-}
+CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/${cmd} cmd/${cmd}.go

--- a/images/egress-router/Dockerfile
+++ b/images/egress-router/Dockerfile
@@ -1,8 +1,15 @@
 FROM golang:1.13 as builder
+
+ENV GOPATH /go
 WORKDIR /go/src/github.com/openshift/egress-router-cni
+
 COPY . .
 RUN ./hack/build-go.sh
 
 FROM openshift/origin-base
-
 COPY --from=builder /go/src/github.com/openshift/egress-router-cni/bin/egress-router /egress-router
+
+LABEL io.k8s.display-name="Egress Router CNI" \
+      io.k8s.description="CNI Plugin for Egress Router" \
+      io.openshift.tags="openshift" \
+      maintainer="Daniel Mellado <dmellado@redhat.com>"


### PR DESCRIPTION
This commit fixes the Makefile and adds the hack/build-go.sh script to
create the build image.