### PR TITLE
Fix makefile for creating egress-router image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ unexport GOPATH
 
 GO_BUILD_BINDIR = _output
 GO_BUILD_PACKAGES = \
-    ./cmd/... 
+    ./cmd/...
 GO_BUILD_PACKAGES_EXPANDED =$(shell GO111MODULE=on $(GO) list $(GO_MOD_FLAGS) $(GO_BUILD_PACKAGES))
 
 # Include the library makefile
@@ -26,3 +26,8 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 # It will generate target "image-$(1)" for builing the image and binding it as a prerequisite to target "images".
 
 $(call build-image,egress-router,egress-router,./images/egress-router/Dockerfile,.)
+
+build-image-egress-router-test:
+	podman build --no-cache -f images/egress-router/Dockerfile -t egress-router-test .
+
+.PHONY: build-image-egress-router-test

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu
+
+REPO=github.com/openshift/egress-router-cni
+CMD="egress-router"
+GLDFLAGS=${GLDFLAGS:-}
+GOFLAGS=${GOFLAGS:--mod=vendor}
+
+eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+
+: "${GOOS:=${GOHOSTOS}}"
+: "${GOARCH:=${GOHOSTARCH}}"
+
+cd "$(git rev-parse --show-cdup)"
+
+eval $(go env)
+GO111MODULE=${GO111MODULE} CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/${CMD} ${REPO}/cmd/${CMD}
+#CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/${cmd} cmd/${cmd}.go

--- a/images/egress-router/Dockerfile
+++ b/images/egress-router/Dockerfile
@@ -1,8 +1,12 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as rhel8
 FROM golang:1.13 as builder
 WORKDIR /go/src/github.com/openshift/egress-router-cni
 COPY . .
 RUN ./hack/build-go.sh
 
 FROM openshift/origin-base
-
-COPY --from=builder /go/src/github.com/openshift/egress-router-cni/bin/egress-router /egress-router
+COPY --from=builder /go/src/github.com/openshift/egress-router-cni/bin/egress-router /usr/src/egress-router-cni/bin/egress-router
+LABEL io.k8s.display-name="Egress Router CNI" \
+      io.k8s.description="CNI Plugin for Egress Router" \
+      io.openshift.tags="openshift" \
+      maintainer="Daniel Mellado <dmellado@redhat.com>"


### PR DESCRIPTION
This commit fixes the Makefile and adds the hack/build-go.sh script to
create the build image. It also changes the Dockerfile to take go.mod
into consideration.
