### PR TITLE
Add Daniel Mellado to owners/reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,12 +4,13 @@ reviewers:
   - dcbw
   - JacobTanenbaum
   - juanluisvaladas
-  - pecameron
   - rcarrillocruz
   - squeed
+  - danielmellado
 approvers:
   - danwinship
   - dcbw
   - knobunc
   - rcarrillocruz
   - squeed
+  - danielmellado


### PR DESCRIPTION
This commit adds Daniel Mellado to both owners and reviewers list. It
also deletes some members who haven't been around for a while.