### PR TITLE
Add BZ component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,3 +14,4 @@ approvers:
   - rcarrillocruz
   - squeed
   - danielmellado
+component: "Networking"


### PR DESCRIPTION
This PR adds the BZ component to the OWNERS file for the sake of creating the
image on ART.