### PR TITLE
[4.7] Remove CGO flag from rhel Dockerfile

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -2,7 +2,6 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 
 ADD . /go/src/github.com/openshift/egress-router-cni
 WORKDIR /go/src/github.com/openshift/egress-router-cni
 ENV GO111MODULE=on
-ENV CGO_ENABLED=1
 ENV VERSION=rhel8 COMMIT=unset
 RUN go build -mod vendor -o bin/egress-router cmd/egress-router/egress-router.go
 


### PR DESCRIPTION
This PR removes the CGO flag from dockerfile in order to mitigate ths
following vulnerabilities:
  * https://access.redhat.com/security/cve/CVE-2020-28367
  * https://access.redhat.com/security/cve/CVE-2020-28366

The vulnerability is specific to the building of Go code itself.

(cherry picked from commit e144bc3ced86fec9a97a90529671b9ffc75dcf1b)