### PR TITLE
Fix gofmt linting issues on macvlan_test

### DIFF
--- a/pkg/macvlan/macvlan.go
+++ b/pkg/macvlan/macvlan.go
@@ -240,7 +240,7 @@ func loadIPConfig(ipc *types.IPConfig, podNamespace string) (*types.IP, map[stri
 		return ip, nil, nil
 	} else if cm.Data["podIP"] != "" {
 		podIP := map[string]types.IP{}
-		if err := json.Unmarshal([]byte(cm.Data["podIP"]), podIP); err != nil {
+		if err := json.Unmarshal([]byte(cm.Data["podIP"]), &podIP); err != nil {
 			logging.Errorf("failed to parse 'podIP' in ConfigMap %s/%s: %v", ipc.Namespace, ipc.Name, err)
 			return nil, nil, fmt.Errorf("failed to parse 'podIP' in ConfigMap %s/%s: %v", ipc.Namespace, ipc.Name, err)
 		}

--- a/pkg/macvlan/macvlan_test.go
+++ b/pkg/macvlan/macvlan_test.go
@@ -50,17 +50,17 @@ func TestFillNetConfDefaults(t *testing.T) {
 		{
 			desc:           "missing explicit interface type when cloud provider specified",
 			inpNetConf:     &types.NetConf{},
-			inpClusterConf: &types.ClusterConf{"testProvider"},
+			inpClusterConf: &types.ClusterConf{CloudProvider: "testProvider"},
 			errMatch:       fmt.Errorf("must specify explicit interfaceType for cloud provider"),
 		},
 		{
 			desc:           "non `macvlan` interface specified",
 			inpNetConf:     &types.NetConf{InterfaceType: "nonMacVlanIface"},
-			inpClusterConf: &types.ClusterConf{"testProvider"},
-			outNetConf: 	&types.NetConf{InterfaceType: "nonMacVlanIface"},
+			inpClusterConf: &types.ClusterConf{CloudProvider: "testProvider"},
+			outNetConf:     &types.NetConf{InterfaceType: "nonMacVlanIface"},
 		},
 		{
-			desc:			"error: unable to get the default route interface name",
+			desc:           "error: unable to get the default route interface name",
 			inpNetConf:     &types.NetConf{},
 			inpClusterConf: &types.ClusterConf{},
 			errMatch:       fmt.Errorf("unable to get default route interface name"),
@@ -69,7 +69,7 @@ func TestFillNetConfDefaults(t *testing.T) {
 			},
 		},
 		{
-			desc:			"error: unable to get MTU on master interface",
+			desc:           "error: unable to get MTU on master interface",
 			inpNetConf:     &types.NetConf{},
 			inpClusterConf: &types.ClusterConf{},
 			errMatch:       fmt.Errorf("unable to get MTU on master interface"),


### PR DESCRIPTION
This commit fixes gofmt lingint issues on macvlan_test.go after
make-updategofmt is available.