### PR TITLE
Bug 2034411: Call ip6tables for v6 mode

### DIFF
--- a/pkg/macvlan/macvlan.go
+++ b/pkg/macvlan/macvlan.go
@@ -490,7 +490,13 @@ func macvlanCmdAdd(args *skel.CmdArgs) error {
 			}
 		}
 
-		ipt, err := iptables.New()
+		var ipt *iptables.IPTables
+		if isIPv6 {
+			ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		} else {
+			ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		}
+
 		if err != nil {
 			logging.Errorf("failed to get IPTables: %v", err)
 			return fmt.Errorf("failed to get IPTables: %v", err)


### PR DESCRIPTION
We are presently always calling iptables whether its v4 or v6 stack.
This ends up not adding iptable rules for v6 stack. Let's use the 
`iptables.NewWithProtocol` function that iptables pkg provides
and rectify this.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>