### PR TITLE
OCPBUGS-53096: Build openshift container based on 4.19 image

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,17 +1,17 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS rhel9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS rhel9
 ADD . /go/src/github.com/openshift/egress-router-cni
 WORKDIR /go/src/github.com/openshift/egress-router-cni
 ENV GO111MODULE=on
 ENV VERSION=rhel9 COMMIT=unset
 RUN go build -mod vendor -o bin/egress-router cmd/egress-router/egress-router.go
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS rhel8
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.23-openshift-4.19 AS rhel8
 ADD . /go/src/github.com/openshift/egress-router-cni
 WORKDIR /go/src/github.com/openshift/egress-router-cni
 ENV GO111MODULE=on
 RUN go build -mod vendor -o bin/egress-router cmd/egress-router/egress-router.go
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 RUN dnf install -y util-linux && dnf clean all && \
     mkdir -p /usr/src/egress-router-cni/bin/ && \
     mkdir -p /usr/src/egress-router-cni/rhel8/bin && \


### PR DESCRIPTION
Running this container in a TDX confidential cluster resulted in a segfault. That segfault could be related to a glibc bug reported for some guests (see https://sourceware.org/bugzilla/show_bug.cgi?id=29953).

I couldn't reproduce the issue on other images that were built onto the 4.19 image. Trying out to test the hypothesis and a possible _fix_.

This patch fixes the segfault `egress-router-binary-copy` caused while installing an OCP 4.19 cluster on TDX confidential machines in GCP.