### PR TITLE
stop installing rpms that are already in the base image

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -12,8 +12,7 @@ ENV GO111MODULE=on
 RUN go build -mod vendor -o bin/egress-router cmd/egress-router/egress-router.go
 
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
-RUN dnf install -y util-linux && dnf clean all && \
-    mkdir -p /usr/src/egress-router-cni/bin/ && \
+RUN mkdir -p /usr/src/egress-router-cni/bin/ && \
     mkdir -p /usr/src/egress-router-cni/rhel8/bin && \
     mkdir -p /usr/src/egress-router-cni/rhel9/bin
 COPY --from=rhel9 /go/src/github.com/openshift/egress-router-cni/bin/egress-router /usr/src/egress-router-cni/bin/egress-router


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-13475

this rpm is present in the base image and this attempt to install breaks hermetic builds:

```
> docker run quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:e48a167592f91827f6dbe2bcec289ea4c0ec1074b2312f9419f9be92f355e362 rpm -qa | grep util-linux
util-linux-core-2.37.4-18.el9.aarch64
util-linux-2.37.4-18.el9.aarch64
```