### PR TITLE
OCPBUGS-83286: Fix swallowed errors in cmdAdd/cmdDel causing empty CNI result

### DIFF
--- a/cmd/egress-router/egress-router.go
+++ b/cmd/egress-router/egress-router.go
@@ -17,11 +17,9 @@ func cmdCheck(args *skel.CmdArgs) error {
 }
 
 func cmdAdd(args *skel.CmdArgs) error {
-	macvlan.CmdAdd(args)
-	return nil
+	return macvlan.CmdAdd(args)
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	macvlan.CmdDel(args)
-	return nil
+	return macvlan.CmdDel(args)
 }


### PR DESCRIPTION
cmdAdd and cmdDel were discarding the errors returned by macvlan.CmdAdd/macvlan.CmdDel and always returning nil. When an error occurred (e.g. during a pod sandbox race condition), the plugin would exit 0 with no JSON on stdout, causing the caller to fail with "failed to unmarshal raw result: unexpected end of JSON input".

Return the errors so the CNI skel framework can emit proper error JSON and a non-zero exit code on failure.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in egress router to properly propagate errors from underlying network operations to the CNI runtime, improving reliability and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->