### PR TITLE
OCPBUGS-83863: Remove rhel8 build stage, strip debug info

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -3,7 +3,7 @@ ADD . /go/src/github.com/openshift/egress-router-cni
 WORKDIR /go/src/github.com/openshift/egress-router-cni
 ENV GO111MODULE=on
 ENV VERSION=rhel9 COMMIT=unset
-RUN go build -mod vendor -o bin/egress-router cmd/egress-router/egress-router.go
+RUN go build -mod vendor -ldflags '-s -w' -o bin/egress-router cmd/egress-router/egress-router.go
 
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 RUN dnf install -y util-linux && dnf clean all && \

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -5,20 +5,10 @@ ENV GO111MODULE=on
 ENV VERSION=rhel9 COMMIT=unset
 RUN go build -mod vendor -o bin/egress-router cmd/egress-router/egress-router.go
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.23-openshift-4.19 AS rhel8
-ADD . /go/src/github.com/openshift/egress-router-cni
-WORKDIR /go/src/github.com/openshift/egress-router-cni
-ENV GO111MODULE=on
-RUN go build -mod vendor -o bin/egress-router cmd/egress-router/egress-router.go
-
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 RUN dnf install -y util-linux && dnf clean all && \
-    mkdir -p /usr/src/egress-router-cni/bin/ && \
-    mkdir -p /usr/src/egress-router-cni/rhel8/bin && \
-    mkdir -p /usr/src/egress-router-cni/rhel9/bin
+    mkdir -p /usr/src/egress-router-cni/bin/
 COPY --from=rhel9 /go/src/github.com/openshift/egress-router-cni/bin/egress-router /usr/src/egress-router-cni/bin/egress-router
-COPY --from=rhel9 /go/src/github.com/openshift/egress-router-cni/bin/egress-router /usr/src/egress-router-cni/rhel9/bin/egress-router
-COPY --from=rhel8 /go/src/github.com/openshift/egress-router-cni/bin/egress-router /usr/src/egress-router-cni/rhel8/bin/egress-router
 LABEL io.k8s.display-name="Egress Router CNI" \
       io.k8s.description="CNI Plugin for Egress Router" \
       io.openshift.tags="openshift"


### PR DESCRIPTION
Remove the rhel8 build stage and strip debug symbols from binaries.

The rhel9/rhel10 version-specific subdirectories are no longer needed
since openshift/cluster-network-operator#2967 removed the OS detection
logic and now copies binaries directly from the base directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Platform Support Updates**
  * Removed RHEL8-specific build output; RHEL8 runtime artifacts are no longer produced.
  * Runtime now ships a single executable compatible with RHEL9 and RHEL10.
  * Simplified runtime layout and reduced runtime artifact size for a smaller footprint and improved cross-release compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->